### PR TITLE
Add support for closing days

### DIFF
--- a/src/Model/Behavior/ClosingDaysBehavior.php
+++ b/src/Model/Behavior/ClosingDaysBehavior.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Chialab\Calendar\Model\Behavior;
+
+use BEdita\Core\Model\Entity\DateRange;
+use BEdita\Core\Model\Entity\ObjectEntity;
+use Cake\Chronos\ChronosInterface;
+use Cake\Collection\CollectionInterface;
+use Cake\I18n\FrozenTime;
+use Cake\Log\Log;
+use Cake\ORM\Behavior;
+use Cake\ORM\Query;
+use Closure;
+use Generator;
+
+/**
+ * Apply closing days to date ranges.
+ */
+class ClosingDaysBehavior extends Behavior
+{
+    /**
+     * Map of days of week from the name as specified in {@see \BEdita\Core\Model\Entity\DateRange::$params}
+     * to {@see \Cake\Chronos\ChronosInterface} constants.
+     *
+     * @var array<string, int>
+     */
+    protected const WEEKDAYS = [
+        'monday' => ChronosInterface::MONDAY,
+        'tuesday' => ChronosInterface::TUESDAY,
+        'wednesday' => ChronosInterface::WEDNESDAY,
+        'thursday' => ChronosInterface::THURSDAY,
+        'friday' => ChronosInterface::FRIDAY,
+        'saturday' => ChronosInterface::SATURDAY,
+        'sunday' => ChronosInterface::SUNDAY,
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    protected $_defaultConfig = [
+        'implementedFinders' => [
+            'closingDays' => 'findClosingDays',
+        ],
+    ];
+
+    /**
+     * Finder to filter and apply closing days when filtering by date ranges.
+     *
+     * @param \Cake\ORM\Query $query Query object.
+     * @return \Cake\ORM\Query
+     */
+    public function findClosingDays(Query $query): Query
+    {
+        return $query->formatResults(
+            fn (CollectionInterface $results) => $query->isHydrationEnabled()
+            ? $results->map(
+                fn (ObjectEntity $object): ObjectEntity => !$object->has('filtered_date_ranges') && $object->has('date_ranges')
+                    ? $object
+                        ->set(
+                            'filtered_date_ranges',
+                            collection((array)$object->get('date_ranges'))->unfold(Closure::fromCallable([$this, 'applyClosingDays']))
+                        )
+                        ->setAccess('filtered_date_ranges', false)
+                        ->setVirtual(['filtered_date_ranges'], true)
+                    : $object
+            )
+            : $results,
+        );
+    }
+
+    /**
+     * Apply closing days to a {@see \BEdita\Core\Model\Entity\DateRange}.
+     *
+     * @param \BEdita\Core\Model\Entity\DateRange $dr Date range.
+     * @return \Generator<\BEdita\Core\Model\Entity\DateRange>
+     */
+    protected function applyClosingDays(DateRange $dr): Generator
+    {
+        $params = is_string($dr->params) ? json_decode($dr->params, true) : $dr->params;
+        $closingDays = array_intersect_key(
+            static::WEEKDAYS,
+            array_filter((array)($params['weekdays'] ?? []), fn ($val): bool => $val === false),
+        );
+        if (empty($closingDays)) {
+            // No closing days for this DateRange. Let's avoid useless expensive computation.
+            yield $dr;
+
+            return;
+        }
+
+        $start = new FrozenTime($dr->start_date);
+        if ($dr->end_date === null && in_array($start->dayOfWeek, $closingDays)) {
+            // This is a unit set where its only element is also excluded by its parameters as it is a closing day.
+            // Albeit weird, we should be consistent and return an empty set.
+            Log::debug(sprintf('Date range #%d for object #%d (%s) does not have a end date, and its only date is also a closing day.', $dr->id, $dr->object_id, $start->toIso8601String()));
+
+            return;
+        }
+
+        // Go back to start of first week, then go back another hour so that "next monday" doesn't jump to the next week already.
+        $it = $start->startOfWeek()->subHour();
+        $closingDays = array_values($closingDays);
+        $subRanges = [];
+        while ($it <= $dr->end_date) {
+            $day = current($closingDays);
+            /** @var \Cake\I18n\FrozenTime $it */
+            $it = $it->next($day);
+            $subRanges[] = new DateRange(['start_date' => $it->subDay()->endOfDay(), 'end_date' => $it->addDay()]);
+
+            if (next($closingDays) === false) {
+                reset($closingDays);
+            }
+        }
+
+        yield from DateRange::diff([$dr], $subRanges);
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2,11 +2,41 @@
 
 namespace Chialab\Calendar;
 
+use ArrayObject;
+use BEdita\Core\Model\Table\ObjectsBaseTable;
+use BEdita\Core\Model\Table\ObjectsTable;
 use Cake\Core\BasePlugin;
+use Cake\Core\PluginApplicationInterface;
+use Cake\Event\Event;
+use Cake\Event\EventManager;
+use Cake\ORM\Query;
+use Cake\ORM\Table;
 
 /**
  * Plugin for Chialab\Calendar
  */
 class Plugin extends BasePlugin
 {
+    /**
+     * @inheritDoc
+     */
+    public function bootstrap(PluginApplicationInterface $app)
+    {
+        parent::bootstrap($app);
+
+        EventManager::instance()
+            ->on('Model.initialize', function (Event $event): void {
+                $table = $event->getSubject();
+                if (!$table instanceof ObjectsTable && !$table instanceof ObjectsBaseTable) {
+                    return;
+                }
+
+                $table->addBehavior('Chialab/Calendar.ClosingDays');
+                $table->getEventManager()
+                    ->on(
+                        'Model.beforeFind',
+                        fn (Event $event, Query $query, ArrayObject $options, bool $primary): Query => $primary ? $query->find('closingDays') : $query,
+                    );
+            });
+    }
 }


### PR DESCRIPTION
This PR adds support for closing days.

When `Chialab/Calendar` plugin is loaded, every object type that is linked to **DateRanges** will have an additional `filtered_date_ranges` property in the object's metadata. Such property will be populated with the values from `date_ranges` with the ranges that only happen during some weekdays split to reflect the actual hours.

This happens automatically every time an object is fetched, thus there should be no need for applying additional finders (except when containing nested entities without re-loading the hydrated objects).

For instance if a date range from 2022-08-01T00:00:00 to 2022-08-31T10:30:00 is set to happen only on Wednesdays, instead of one date range, in the `filtered_date_ranges` there will be five entries:
- 2022-08-03T00:00:00 to 2022-08-03T23:59:59
- 2022-08-10T00:00:00 to 2022-08-10T23:59:59
- 2022-08-17T00:00:00 to 2022-08-17T23:59:59
- 2022-08-24T00:00:00 to 2022-08-24T23:59:59
- 2022-08-31T00:00:00 to 2022-08-31T10:30:00

Note how the ending hour (10:30:00) is only used for the last entry in the set, as it may not be safe to assume that the hour for start_date and end_date is to be reflected on all Wednesdays in the set.