### PR TITLE
Always prepend closing days formatter

### DIFF
--- a/src/Model/Behavior/ClosingDaysBehavior.php
+++ b/src/Model/Behavior/ClosingDaysBehavior.php
@@ -65,6 +65,7 @@ class ClosingDaysBehavior extends Behavior
                     : $object
             )
             : $results,
+            Query::PREPEND
         );
     }
 

--- a/src/Model/Behavior/ClosingDaysBehavior.php
+++ b/src/Model/Behavior/ClosingDaysBehavior.php
@@ -65,7 +65,7 @@ class ClosingDaysBehavior extends Behavior
                     : $object
             )
             : $results,
-            Query::PREPEND
+            Query::PREPEND,
         );
     }
 


### PR DESCRIPTION
Prepend the closing days formatter in order to avoid issues with grouped event lists.