### PR TITLE
Use start of day for fallback range

### DIFF
--- a/src/Controller/Component/CalendarComponent.php
+++ b/src/Controller/Component/CalendarComponent.php
@@ -247,7 +247,7 @@ class CalendarComponent extends Component
      */
     public function getComputedRange(): array
     {
-        $startDate = new FrozenTime();
+        $startDate = (new FrozenTime())->startOfDay();
         $endDate = null;
         $range = $this->getRangeFilter();
         if (!empty($range)) {


### PR DESCRIPTION
Currently, performing a search without a date filter and with a "today" (or similar) date filter yields different results due to an inconsistency in setting the default startDate.

When a date filter is applied, the time is always set to the beginning of the day, week, month, or specified period. Additionally, when the $range parameter is provided as an array, we already set the time to the start of the specified range:

```
$startDate = (new FrozenTime($range[0] ?? 'now'))->startOfDay();
```

However, this adjustment is not applied when setting the $startDate variable at the beginning of the getComputedRange function (the fallback value).

On the frontend side, when the user sets the range to "today," events that occurred earlier in the day but are no longer active still appear.
When no range is specified, we aim for consistency in the "start" date. The same events should be visible as with the "today" filter, except that there’s no restriction on the end of the current day. Hence, the need for this adjustment.